### PR TITLE
feat: Add Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ $schedule->command('unblock:expired')->everyMinute();
 
 > **Note:**
 > Don't forget to add the command to the `App\Console\Kernel` `schedule()` method.
+> 
+ 
+### Events
+
+When a User is blocked, a `UserBlocked` event is fired.
+
+When a User is unblocked, a `UserUnblocked` event is fired.
+
+The `User` Model of the blocked or unblocked User is passed to the event so you can listen for these events and perform further actions.
 
 ## Testing
 

--- a/src/Concerns/CanBlock.php
+++ b/src/Concerns/CanBlock.php
@@ -3,6 +3,8 @@
 namespace Cjmellor\Blockade\Concerns;
 
 use Carbon\Carbon;
+use Cjmellor\Blockade\Events\UserBlocked;
+use Cjmellor\Blockade\Events\UserUnblocked;
 use Cjmellor\Blockade\Exceptions\CannotBlockSelfException;
 use Cjmellor\Blockade\Exceptions\HasNotBlockedUserException;
 use Cjmellor\Blockade\Exceptions\UserAlreadyBlockedException;
@@ -48,6 +50,8 @@ trait CanBlock
         $this->blockedUsers()
             ->attach(id: $this->modelInstance($user), attributes: $expiresAt !== null ? ['expires_at' => $expiresAt] : []);
 
+        event(new UserBlocked($this->blockedUsers()->whereId($this->modelInstance($user)->id)->first()));
+
         return true;
     }
 
@@ -62,6 +66,8 @@ trait CanBlock
             condition: ! $this->blockedUsers()->whereId($this->modelInstance($user)->id)->exists(),
             exception: HasNotBlockedUserException::class,
         );
+
+        event(new UserUnblocked($this->blockedUsers()->whereId($this->modelInstance($user)->id)->first()));
 
         $this->blockedUsers()->detach(ids: $this->modelInstance($user));
 

--- a/src/Events/UserBlocked.php
+++ b/src/Events/UserBlocked.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cjmellor\Blockade\Events;
+
+class UserBlocked
+{
+    public function __construct(
+        public $user,
+    ) {
+    }
+}

--- a/src/Events/UserUnblocked.php
+++ b/src/Events/UserUnblocked.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cjmellor\Blockade\Events;
+
+class UserUnblocked
+{
+    public function __construct(
+        public $user,
+    ) {
+    }
+}


### PR DESCRIPTION
This PR adds two Events.

1) When a User is blocked, a `UserBlocked` Event is run.
2) When a User in unblocked, a `UserUnblocked` Event is run.

The User Model of the affected User is passed to the Event so a User can listen for it and peform further actions.